### PR TITLE
Fix bug with truncated tweets not matching rules

### DIFF
--- a/scan_and_retweet.py
+++ b/scan_and_retweet.py
@@ -7,6 +7,7 @@ import twitter
 
 
 api = twitter.Api(
+    tweet_mode='extended',
     consumer_key=os.environ['CONSUMER_KEY'],
     consumer_secret=os.environ['CONSUMER_SECRET'],
     access_token_key=os.environ['ACCESS_TOKEN_KEY'],
@@ -31,7 +32,7 @@ def tweet_matches_rules(tweet, rules):
 
 def tweet_matches_rule(tweet, rule):
     screen_name = tweet.user.screen_name.lower()
-    text = tweet.text.lower()
+    text = tweet.full_text.lower()
     return (screen_name == rule['user'].lower()) and (rule['hashtag'].lower() in text)
 
 
@@ -45,7 +46,7 @@ def scan_and_retweet():
     # For every tweet, see if it matches a rule
     for tweet in reversed(tweets):
         print
-        print "Considering %r" % tweet.text
+        print "Considering %r" % tweet.full_text
         # Have we retweeted this already?
         if tweet.retweeted:
             print "  Skipping, we have retweeted already"


### PR DESCRIPTION
We spotted a bug where this tweet should have been retweeted but wasn't:
https://twitter.com/MetroFieldGuide/status/860269638822776833

It turns out the root cause was recent changes to Twitter's API, documented
here: https://dev.twitter.com/overview/api/upcoming-changes-to-tweets - tweets
can now be longer than 140 characters (since certain aspects of tweets are no
longer included in the character count), but the Twitter API was changed to
truncate at 140 characters to avoid breaking existing clients.

The full text of the tweet we care about is:

    And the answer is....feet! Butterflies & moths have sensors on their
    feet which allow them to taste which plant they are on. #CityNatureQuiz

But the tweet in question came through the API looking like this: 

    u'text': u'And the answer is....feet! Butterflies &amp; moths have 
    sensors on their feet which allow them to taste which plant 
    the\u2026 https://t.co/Bkdxhhz3r5',

The truncation meant that the script couldn't see the hashtag, so it didn't
match the rule and retweet the tweet.

The fix is to send tweet_mode='extended' to the API for every request - which
twitter-python supports as an option. Then use tweet.full_text instead of
tweet.text